### PR TITLE
 fix: unable to call focus() on element #13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@alaskaairux/ods-inputtext",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/ods-inputtext.js
+++ b/src/ods-inputtext.js
@@ -42,6 +42,10 @@ export default class OdsInputText extends LitElement {
     };
   }
 
+  focus() {
+    this.inputElement.focus();
+  }
+
   connectedCallback() {
     super.connectedCallback();
     this.isValid = !this.error;

--- a/src/ods-inputtext.js
+++ b/src/ods-inputtext.js
@@ -42,10 +42,6 @@ export default class OdsInputText extends LitElement {
     };
   }
 
-  focus() {
-    this.inputElement.focus();
-  }
-
   connectedCallback() {
     super.connectedCallback();
     this.isValid = !this.error;
@@ -53,6 +49,10 @@ export default class OdsInputText extends LitElement {
 
   firstUpdated() {
     this.inputElement = this.renderRoot.querySelector('input');
+  }
+
+  focus() {
+    this.inputElement.focus();
   }
 
   getIconAsHtml(icon) {

--- a/test/ods-inputtext.test.js
+++ b/test/ods-inputtext.test.js
@@ -142,7 +142,7 @@ describe('ods-inputtext', () => {
 
     el.focus();
     expect(document.activeElement === el).to.be.true;
-  })
+  });
 
   it('is accessible', async () => {
     const el = await fixture(html`

--- a/test/ods-inputtext.test.js
+++ b/test/ods-inputtext.test.js
@@ -135,6 +135,15 @@ describe('ods-inputtext', () => {
     expect(spy.callCount).to.be.greaterThan(0);
   });
 
+  it('is programmatically focusable', async () => {
+    const el = await fixture(html`
+      <ods-inputtext label="Label"></ods-inputtext>
+    `);
+
+    el.focus();
+    expect(document.activeElement === el).to.be.true;
+  })
+
   it('is accessible', async () => {
     const el = await fixture(html`
       <ods-inputtext label="Label text"></ods-inputtext>


### PR DESCRIPTION
# Alaska Airlines Pull Request

**Fixes:** #13 

## Summary:

This makes the element programmatically focusable. In order to call `focus()` on the custom element, we need to define that method as part of the custom element. 

Change has been tested in Chrome, IE11, and Firefox. This change does not break default focus behavior when tabbing.

## Type of change:

Please delete options that are not relevant.

- [ ] New capability 
- [x] Revision of an existing capability
- [ ] Infrastructure change (automation, etc.)
- [ ] Other (please elaborate) 


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._ 

**Thank you for your submission!**<br>
-- Orion Design System Team
