### PR TITLE
fix: styling issues in IE11 #15

### DIFF
--- a/src/style.scss
+++ b/src/style.scss
@@ -27,10 +27,14 @@ ods-inputtext-light {
 
 
 .inputText {
-  border: 0 solid var(--color-base-shark);
+  // Border, padding, and margin styles are written longhand on purpose to prevent issues with ShadyCSS styling in IE11
+  // See issue #15 in this repo  
+  border: 0 solid;
+  border-color: var(--color-base-shark);
   border-radius: 0;
-  border-width: 0 0 var(--border-width-thin);
-  padding: var(--size-scale-xl) var(--size-scale-xl) var(--size-scale-sml) 0;
+  border-bottom-width: var(--border-width-thin);
+  padding: var(--size-scale-xl) var(--size-scale-xl) var(--size-scale-sml);
+  padding-left: 0;
   position: relative;
   transition: all 0.3s cubic-bezier(0.215, 0.61, 0.355, 1);
   width: 100%;
@@ -54,7 +58,8 @@ ods-inputtext-light {
   &--filled {
     & + .inputText-label {
       font-size: 0.875rem;
-      padding: var(--size-scale-sml) 0 0;
+      padding: 0;
+      padding-top: var(--size-scale-sml);
     }
   }
 
@@ -81,13 +86,17 @@ ods-inputtext-light {
   pointer-events: none;
   position: absolute;
   transition: all 0.3s cubic-bezier(0.215, 0.61, 0.355, 1);
-  padding: var(--size-scale-xl) 0 0;
+  padding: 0;
+  padding-top: var(--size-scale-xl);
 }
 
 .inputText-helpText {
   font-size: 0.875rem;
   color: var(--color-base-shark);
-  margin: var(--size-scale-micro) 0;
+  margin-top: var(--size-scale-micro);
+  margin-bottom: var(--size-scale-micro);
+  margin-left: 0;
+  margin-right: 0;
 
   &.error {
     color: var(--color-base-chili);


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

**Fixes:** #15

## Summary:

IE11 uses ShadyCSS to polyfill Shadow DOM styling and behavior. ShadyCSS removes uses of var when the variable is not declared in the scope of the component, which produces incorrect CSS. To get around this, we break up the shorthand CSS rules for padding, margin, and border so variables are only used by themselves. See [issue discussion](https://github.com/AlaskaAirlines/ods-inputtext/issues/15#issuecomment-637859255) for more details.

Screenshot of fixed component in IE11:
![image](https://user-images.githubusercontent.com/4992896/83661099-8689ea80-a57a-11ea-8982-de32d15c9978.png)


## Type of change:

- [x] Revision of an existing capability

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._ 

**Thank you for your submission!**<br>
-- Orion Design System Team
