### PR TITLE
fix: validity not updating on error change #19

### DIFF
--- a/src/ods-inputtext.js
+++ b/src/ods-inputtext.js
@@ -24,6 +24,9 @@ export default class OdsInputText extends LitElement {
     // Default property values
     this.id = "input-element";
     this.label = "Input label";
+
+    // Internal error state used in custom getter/setter
+    this._error = null;
   }
 
   static get properties() {
@@ -40,6 +43,17 @@ export default class OdsInputText extends LitElement {
       isValid:                 { type: Boolean },
       required:                { type: Boolean }
     };
+  }
+
+  set error(value) {
+    // custom setter so we can re-validate on update
+    let oldVal = this._error;
+    this._error = value;
+    this.requestUpdate('error', oldVal).then(this.validate.bind(this));
+  } 
+
+  get error() {
+    return this._error;
   }
 
   connectedCallback() {
@@ -85,7 +99,8 @@ export default class OdsInputText extends LitElement {
      * If the error property is set, then the error message should persist
      * and take precedence over client side validation
      */
-    if (this.error) {
+    if (this.error && this.error.length > 0) {
+      this.isValid = false;
       return;
     }
 

--- a/test/ods-inputtext.test.js
+++ b/test/ods-inputtext.test.js
@@ -144,6 +144,26 @@ describe('ods-inputtext', () => {
     expect(document.activeElement === el).to.be.true;
   });
 
+  it('updates validity when error message set after creation', async () => {
+    const el = await fixture(html`
+      <ods-inputtext></ods-inputtext>
+    `);
+
+    el.error = 'New error message';
+    await elementUpdated(el);
+    expect(el.isValid).to.be.false;
+  });
+
+  it('updates validity when error message removed after creation', async () => {
+    const el = await fixture(html`
+      <ods-inputtext error="Test error"></ods-inputtext>
+    `);
+
+    el.error = '';
+    await elementUpdated(el);
+    expect(el.isValid).to.be.true;
+  });
+
   it('is accessible', async () => {
     const el = await fixture(html`
       <ods-inputtext label="Label text"></ods-inputtext>


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

**Fixes:** #19 

## Summary:

This updates the isValid state whenever the error prop changes using a custom setter, as suggested in the [LitElement docs](https://lit-element.polymer-project.org/guide/properties#haschanged).

This PR fixes both problems described in the linked issue -- adding an error after initial render displays an error message accordingly, and removing an error after initial render removes the error message.

## Type of change:

Please delete options that are not relevant.

- [x] Revision of an existing capability


## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._ 

**Thank you for your submission!**<br>
-- Orion Design System Team
